### PR TITLE
Culture output folders

### DIFF
--- a/Center windows winui/Center windows winui.csproj
+++ b/Center windows winui/Center windows winui.csproj
@@ -59,7 +59,7 @@
     <HasPackageAndPublishMenu>true</HasPackageAndPublishMenu>
   </PropertyGroup>
 
-	<Target Name="RemoveFoldersWithMuiFiles" AfterTargets="Build">
+	<Target Name="RemoveFoldersWithMuiFiles" AfterTargets="CopyFilesToOutputDirectory">
 
 		<ItemGroup>
 			<!-- Create a list of the languages your need to keep.-->


### PR DESCRIPTION
Modify AfterTargets to remove unwanted language files and folders in output directory.