### PR TITLE
Load image win32

### DIFF
--- a/Center windows winui/App.xaml.cs
+++ b/Center windows winui/App.xaml.cs
@@ -76,7 +76,10 @@ public partial class App : Application
             services.AddSingleton<IMouseHookService, MouseHookService>();
 
             // Tray Icon Service
-            services.AddSingleton<ITrayIconService, TrayIconService>(sp => new TrayIconService(MainWindow));
+            services.AddSingleton<GdiPlusIconLoader>();
+            services.AddSingleton<Win2DIconLoader>();
+            services.AddSingleton<IconLoaderFactory>();
+            services.AddSingleton<ITrayIconService, TrayIconService>(sp => new TrayIconService(MainWindow, sp.GetRequiredService<IconLoaderFactory>()));
 
             // Views and ViewModels
             services.AddSingleton<SelectWindowViewModel>();

--- a/Center windows winui/Center windows winui.csproj
+++ b/Center windows winui/Center windows winui.csproj
@@ -40,6 +40,7 @@
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
     <PackageReference Include="CommunityToolkit.WinUI.Controls.SettingsControls" Version="8.2.250402" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.7" />
+    <PackageReference Include="Microsoft.Graphics.Win2D" Version="1.3.2" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.7.250606001" />
     <PackageReference Include="Microsoft.Xaml.Behaviors.WinUI.Managed" Version="3.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />

--- a/Center windows winui/Contracts/Services/IIconLoader.cs.cs
+++ b/Center windows winui/Contracts/Services/IIconLoader.cs.cs
@@ -6,8 +6,9 @@ public interface IIconLoader
     /// ready to be used.
     /// </summary>
     /// <param name="path">The file path of the image to load (png, jpg, etc.).</param>
+    /// <param name="size">The size of the icon to load, typically 16, 32, or 48 pixels.</param>
     /// <returns>A task that represents the asynchronous operation. The task result is a handle to the loaded icon as an <see
     /// cref="IntPtr"/>.</returns>
-    Task<IntPtr> LoadIconAsync(string path);
+    Task<IntPtr> LoadIconAsync(string path, uint size);
 
 }

--- a/Center windows winui/Contracts/Services/IIconLoader.cs.cs
+++ b/Center windows winui/Contracts/Services/IIconLoader.cs.cs
@@ -1,0 +1,13 @@
+﻿namespace CenterWindow.Contracts.Services;
+public interface IIconLoader
+{
+    /// <summary>
+    /// Asynchronously loads an image from the specified file path and returns a handle to the icon (HICON)
+    /// ready to be used.
+    /// </summary>
+    /// <param name="path">The file path of the image to load (png, jpg, etc.).</param>
+    /// <returns>A task that represents the asynchronous operation. The task result is a handle to the loaded icon as an <see
+    /// cref="IntPtr"/>.</returns>
+    Task<IntPtr> LoadIconAsync(string path);
+
+}

--- a/Center windows winui/Contracts/Services/IIconLoaderFactory.cs
+++ b/Center windows winui/Contracts/Services/IIconLoaderFactory.cs
@@ -1,0 +1,8 @@
+﻿namespace CenterWindow.Contracts.Services;
+public interface IIconLoaderFactory
+{
+    /// <summary>
+    /// Returns the appropriate icon loader based on the specified type.
+    /// </summary>
+    IIconLoader GetLoader(IconLoaderType type);
+}

--- a/Center windows winui/Contracts/Services/IconLoaderType.cs
+++ b/Center windows winui/Contracts/Services/IconLoaderType.cs
@@ -1,0 +1,7 @@
+﻿namespace CenterWindow.Contracts.Services;
+
+public enum IconLoaderType
+{
+    GdiPlus,
+    Win2D
+}

--- a/Center windows winui/Interop/NativeMethods.cs
+++ b/Center windows winui/Interop/NativeMethods.cs
@@ -348,5 +348,55 @@ internal static partial class NativeMethods
             PROCESS_VM_READ | PROCESS_VM_WRITE | PROCESS_DUP_HANDLE | PROCESS_CREATE_PROCESS | PROCESS_SET_QUOTA |
             PROCESS_SET_INFORMATION | PROCESS_QUERY_INFORMATION | STANDARD_RIGHTS_REQUIRED | SYNCHRONIZE
     }
-    
+
+
+    // gdi32.dll
+    [DllImport("gdi32.dll", SetLastError = true)]
+    public static extern IntPtr CreateDIBSection(
+        IntPtr hdc,
+        ref BITMAPINFO pbmi,
+        uint usage,
+        out IntPtr ppvBits,
+        IntPtr hSection,
+        uint offset);
+
+    [DllImport("user32.dll", SetLastError = true)]
+    public static extern IntPtr CreateIconIndirect(ref ICONINFO iconInfo);
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct BITMAPINFOHEADER
+    {
+        public uint biSize;
+        public int biWidth;
+        public int biHeight;
+        public ushort biPlanes;
+        public ushort biBitCount;
+        public uint biCompression;
+        public uint biSizeImage;
+        public int biXPelsPerMeter;
+        public int biYPelsPerMeter;
+        public uint biClrUsed;
+        public uint biClrImportant;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct BITMAPINFO
+    {
+        public BITMAPINFOHEADER bmiHeader;
+        public uint bmiColors;  // espacio mínimo para el color table
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct ICONINFO
+    {
+        public bool fIcon;
+        public uint xHotspot;
+        public uint yHotspot;
+        public IntPtr hbmMask;
+        public IntPtr hbmColor;
+    }
+
+    // Constants
+    public const uint BI_RGB = 0u;
+    public const uint DIB_RGB_COLORS = 0u;
 }

--- a/Center windows winui/Interop/NativeMethods.cs
+++ b/Center windows winui/Interop/NativeMethods.cs
@@ -298,6 +298,37 @@ internal static partial class NativeMethods
     [DllImport("gdi32.dll", SetLastError = true)]
     public static extern bool DeleteObject(IntPtr hObject);
 
+    [DllImport("gdiplus.dll", ExactSpelling = true)]
+    public static extern int GdiplusStartup(
+        out IntPtr token,
+        ref GdiplusStartupInput input,
+        IntPtr output);
+
+    [DllImport("gdiplus.dll", ExactSpelling = true)]
+    public static extern void GdiplusShutdown(IntPtr token);
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct GdiplusStartupInput
+    {
+        public uint GdiplusVersion;
+        public IntPtr DebugEventCallback;
+        public bool SuppressBackgroundThread;
+        public bool SuppressExternalCodecs;
+    }
+
+    [DllImport("gdiplus.dll", CharSet = CharSet.Unicode, ExactSpelling = true)]
+    public static extern int GdipCreateBitmapFromFile(
+        string filename,
+        out IntPtr bitmap);
+
+    [DllImport("gdiplus.dll", ExactSpelling = true)]
+    public static extern int GdipCreateHICONFromBitmap(
+        IntPtr bitmap,
+        out IntPtr hicon);
+
+    [DllImport("gdiplus.dll", ExactSpelling = true)]
+    public static extern int GdipDisposeImage(IntPtr image);
+
     public enum PROCESS_ACCESS_TYPES
     {
         PROCESS_TERMINATE = 0x00000001,

--- a/Center windows winui/Services/GdiPlusIconLoader.cs
+++ b/Center windows winui/Services/GdiPlusIconLoader.cs
@@ -33,9 +33,10 @@ public partial class GdiPlusIconLoader : IIconLoader, IDisposable
     /// Ensure that the file path points to a valid image file supported by GDI+. The returned HICON must be destroyed
     /// using <see cref="NativeMethods.DestroyIcon"/> or equivalent system calls to avoid resource leaks.</remarks>
     /// <param name="path">The file path of the icon to load. The path must point to a valid image file.</param>
+    /// <param name="size">The size of the icon to load, in pixels. Default is 16 pixels.</param>
     /// <returns>A task that represents the asynchronous operation. The task result contains a handle to the loaded icon (HICON).
     /// The caller is responsible for releasing the HICON using appropriate system calls when it is no longer needed.</returns>
-    public Task<IntPtr> LoadIconAsync(string path)
+    public Task<IntPtr> LoadIconAsync(string path, uint size = 16)
     {
         // Check if the object has been disposed
         ObjectDisposedException.ThrowIf(_disposed, nameof(GdiPlusIconLoader));

--- a/Center windows winui/Services/GdiPlusIconLoader.cs
+++ b/Center windows winui/Services/GdiPlusIconLoader.cs
@@ -1,0 +1,79 @@
+﻿using CenterWindow.Contracts.Services;
+using CenterWindow.Interop;
+
+namespace CenterWindow.Services;
+
+public partial class GdiPlusIconLoader : IIconLoader, IDisposable
+{
+    private readonly IntPtr _gdiplusToken;
+    private bool _disposed;
+
+  
+    public GdiPlusIconLoader()
+    {
+        // Start up GDI+
+        var input = new NativeMethods.GdiplusStartupInput
+        {
+            GdiplusVersion = 1u,
+            SuppressBackgroundThread = false,
+            SuppressExternalCodecs = false
+        };
+
+        var status = NativeMethods.GdiplusStartup(out _gdiplusToken, ref input, IntPtr.Zero);
+        if (status != 0)
+        {
+            throw new InvalidOperationException($"GdiplusStartup did not start up: {status}");
+        }
+    }
+
+    /// <summary>
+    /// Asynchronously loads an icon from the specified file path and returns a handle to the icon (HICON).
+    /// </summary>
+    /// <remarks>This method uses GDI+ to create a bitmap from the specified file and converts it to an HICON.
+    /// Ensure that the file path points to a valid image file supported by GDI+. The returned HICON must be destroyed
+    /// using <see cref="NativeMethods.DestroyIcon"/> or equivalent system calls to avoid resource leaks.</remarks>
+    /// <param name="path">The file path of the icon to load. The path must point to a valid image file.</param>
+    /// <returns>A task that represents the asynchronous operation. The task result contains a handle to the loaded icon (HICON).
+    /// The caller is responsible for releasing the HICON using appropriate system calls when it is no longer needed.</returns>
+    public Task<IntPtr> LoadIconAsync(string path)
+    {
+        // Check if the object has been disposed
+        ObjectDisposedException.ThrowIf(_disposed, nameof(GdiPlusIconLoader));
+
+        // Create a GDI+ bitmap from the file path
+        NativeMethods.GdipCreateBitmapFromFile(path, out var bitmap);
+
+        // Convert the GDI+ bitmap to an HICON
+        NativeMethods.GdipCreateHICONFromBitmap(bitmap, out var hIcon);
+
+        // Free the GDI+ bitmap
+        NativeMethods.GdipDisposeImage(bitmap);
+
+        // Return the HICON. The caller is responsible for destroying the HICON when done.
+        return Task.FromResult(hIcon);
+    }
+
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    protected virtual void Dispose(bool disposing)
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        // We only shut down GDI+ once if we are disposing.
+        NativeMethods.GdiplusShutdown(_gdiplusToken);
+        _disposed = true;
+    }
+
+    // In case the Dispose method is not called, we ensure that GDI+ is shut down when the object is finalized.
+    ~GdiPlusIconLoader()
+    {
+        Dispose(false);
+    }
+}

--- a/Center windows winui/Services/IconLoaderFactory.cs
+++ b/Center windows winui/Services/IconLoaderFactory.cs
@@ -1,22 +1,19 @@
 ﻿using CenterWindow.Contracts.Services;
 
 namespace CenterWindow.Services;
-public class IconLoaderFactory : IIconLoaderFactory
+public class IconLoaderFactory(GdiPlusIconLoader gdi, Win2DIconLoader win2d) : IIconLoaderFactory
 {
-    private readonly GdiPlusIconLoader _gdi;
-    private readonly Win2DIconLoader _win2d;
+    private readonly GdiPlusIconLoader _gdi = gdi;
+    private readonly Win2DIconLoader _win2d = win2d;
 
-    public IconLoaderFactory(GdiPlusIconLoader gdi, Win2DIconLoader win2d)
+    public IIconLoader GetLoader(IconLoaderType type)
     {
-        _gdi   = gdi;
-        _win2d = win2d;
-    }
-
-    public IIconLoader GetLoader(IconLoaderType type) =>
-        type switch
+        IIconLoader value = type switch
         {
             IconLoaderType.GdiPlus => _gdi,
             IconLoaderType.Win2D => _win2d,
             _ => throw new ArgumentOutOfRangeException(nameof(type), type, null)
         };
+        return value;
+    }
 }

--- a/Center windows winui/Services/IconLoaderFactory.cs
+++ b/Center windows winui/Services/IconLoaderFactory.cs
@@ -1,0 +1,22 @@
+﻿using CenterWindow.Contracts.Services;
+
+namespace CenterWindow.Services;
+public class IconLoaderFactory : IIconLoaderFactory
+{
+    private readonly GdiPlusIconLoader _gdi;
+    private readonly Win2DIconLoader _win2d;
+
+    public IconLoaderFactory(GdiPlusIconLoader gdi, Win2DIconLoader win2d)
+    {
+        _gdi   = gdi;
+        _win2d = win2d;
+    }
+
+    public IIconLoader GetLoader(IconLoaderType type) =>
+        type switch
+        {
+            IconLoaderType.GdiPlus => _gdi,
+            IconLoaderType.Win2D => _win2d,
+            _ => throw new ArgumentOutOfRangeException(nameof(type), type, null)
+        };
+}

--- a/Center windows winui/Services/Win2DIconLoader.cs
+++ b/Center windows winui/Services/Win2DIconLoader.cs
@@ -3,12 +3,10 @@ using CenterWindow.Contracts.Services;
 using CenterWindow.Interop;
 using Microsoft.UI;
 using Microsoft.Graphics.Canvas;
-using Microsoft.Graphics.Canvas.UI;
-using Microsoft.Graphics.Canvas.UI.Xaml;
 using Windows.Foundation;
 
 namespace CenterWindow.Services;
-public class Win2DIconLoader : IIconLoader, IDisposable
+public partial class Win2DIconLoader : IIconLoader, IDisposable
 {
     private readonly CanvasDevice _device;
     private bool _disposed;
@@ -18,7 +16,17 @@ public class Win2DIconLoader : IIconLoader, IDisposable
         _device = CanvasDevice.GetSharedDevice();
     }
 
-    public async Task<IntPtr> LoadIconAsync(string path)
+    /// <summary>
+    /// Asynchronously loads an icon from the specified file path and returns a handle to the icon (HICON).
+    /// </summary>
+    /// <remarks>This method uses Win2D to create a bitmap from the specified file and converts it to an HICON.
+    /// Ensure that the file path points to a valid image file supported by GDI+. The returned HICON must be destroyed
+    /// using <see cref="NativeMethods.DestroyIcon"/> or equivalent system calls to avoid resource leaks.</remarks>
+    /// <param name="path">The file path of the icon to load. The path must point to a valid image file.</param>
+    /// <param name="dim">The size of the icon to load, in pixels. Default is 16 pixels.</param>
+    /// <returns>A task that represents the asynchronous operation. The task result contains a handle to the loaded icon (HICON).
+    /// The caller is responsible for releasing the HICON using appropriate system calls when it is no longer needed.</returns>
+    public async Task<IntPtr> LoadIconAsync(string path, uint dim = 16)
     {
         ObjectDisposedException.ThrowIf(_disposed, nameof(Win2DIconLoader));
 
@@ -26,7 +34,7 @@ public class Win2DIconLoader : IIconLoader, IDisposable
         using var bitmap = await CanvasBitmap.LoadAsync(_device, path);
 
         // Sets the CanvasRenderTarget to the desired size
-        var size = new Size(16, 16);
+        var size = new Size(dim, dim);
         using var rt = new CanvasRenderTarget(
             _device,
             (float)size.Width,

--- a/Center windows winui/Services/Win2DIconLoader.cs
+++ b/Center windows winui/Services/Win2DIconLoader.cs
@@ -1,0 +1,117 @@
+﻿using System.Runtime.InteropServices;
+using CenterWindow.Contracts.Services;
+using CenterWindow.Interop;
+using Microsoft.UI;
+using Microsoft.Graphics.Canvas;
+using Microsoft.Graphics.Canvas.UI;
+using Microsoft.Graphics.Canvas.UI.Xaml;
+using Windows.Foundation;
+
+namespace CenterWindow.Services;
+public class Win2DIconLoader : IIconLoader, IDisposable
+{
+    private readonly CanvasDevice _device;
+    private bool _disposed;
+
+    public Win2DIconLoader()
+    {
+        _device = CanvasDevice.GetSharedDevice();
+    }
+
+    public async Task<IntPtr> LoadIconAsync(string path)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, nameof(Win2DIconLoader));
+
+        // Load the image using Win2D
+        using var bitmap = await CanvasBitmap.LoadAsync(_device, path);
+
+        // Sets the CanvasRenderTarget to the desired size
+        var size = new Size(16, 16);
+        using var rt = new CanvasRenderTarget(
+            _device,
+            (float)size.Width,
+            (float)size.Height,
+            bitmap.Dpi);
+
+        // Render the bitmap onto the CanvasRenderTarget
+        using (var ds = rt.CreateDrawingSession())
+        {
+            ds.Clear(Colors.Transparent);
+            ds.DrawImage(bitmap, new Rect(0, 0, size.Width, size.Height));
+        }
+
+        // Gets the ARGB pixel data from the CanvasRenderTarget
+        var pixels = rt.GetPixelBytes();
+
+        // Create a DIBSection to hold the pixel data
+        IntPtr screenDC = NativeMethods.GetDC(IntPtr.Zero);
+        var header = new NativeMethods.BITMAPINFOHEADER
+        {
+            biSize          = (uint)Marshal.SizeOf<NativeMethods.BITMAPINFOHEADER>(),
+            biWidth         = (int)size.Width,
+            biHeight        = -(int)size.Height, // top-down
+            biPlanes        = 1,
+            biBitCount      = 32,
+            biCompression   = NativeMethods.BI_RGB,
+            biSizeImage     = 0,
+            biXPelsPerMeter = 0,
+            biYPelsPerMeter = 0,
+            biClrUsed       = 0,
+            biClrImportant  = 0
+        };
+        var bmi = new NativeMethods.BITMAPINFO { bmiHeader = header };
+
+        IntPtr ppvBits;
+        var hBitmap = NativeMethods.CreateDIBSection(
+            screenDC,
+            ref bmi,
+            NativeMethods.DIB_RGB_COLORS,
+            out ppvBits,
+            IntPtr.Zero,
+            0);
+
+        // Copy the pixel data to the native bitmap
+        Marshal.Copy(pixels, 0, ppvBits, pixels.Length);
+
+        NativeMethods.ReleaseDC(IntPtr.Zero, screenDC);
+
+        // Packs the pixel data into an ICONINFO structure and creates an HICON
+        var iconInfo = new NativeMethods.ICONINFO
+        {
+            fIcon     = true,
+            xHotspot  = 0,
+            yHotspot  = 0,
+            hbmMask   = IntPtr.Zero,
+            hbmColor  = hBitmap
+        };
+        IntPtr hIcon = NativeMethods.CreateIconIndirect(ref iconInfo);
+
+        // Delete the intermediate HBITMAP object to free resources
+        NativeMethods.DeleteObject(hBitmap);
+
+        return hIcon;
+    }
+
+    // Dispose pattern completo
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    protected virtual void Dispose(bool disposing)
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        // Here we would release any managed resources if needed
+        _disposed = true;
+    }
+
+    ~Win2DIconLoader()
+    {
+        Dispose(false);
+    }
+}


### PR DESCRIPTION
Use GDI+ and Win2D to load an image anc convert it to an icon to be used and drawn at the system task bar.