### PR TITLE
Shell navigation

### DIFF
--- a/Center windows winui/Contracts/Services/INavigationViewService.cs
+++ b/Center windows winui/Contracts/Services/INavigationViewService.cs
@@ -4,19 +4,16 @@ namespace CenterWindow.Contracts.Services;
 
 public interface INavigationViewService
 {
-    IList<object>? MenuItems
-    {
-        get;
-    }
+    IList<object>? MenuItems { get; }
 
-    object? SettingsItem
-    {
-        get;
-    }
+    object? SettingsItem { get; }
 
     void Initialize(NavigationView navigationView);
 
     void UnregisterEvents();
 
     NavigationViewItem? GetSelectedItem(Type pageType);
+
+    // Copilot suggested the following method
+    void SyncSelectedItem(Type pageType);
 }

--- a/Center windows winui/Services/NavigationViewService.cs
+++ b/Center windows winui/Services/NavigationViewService.cs
@@ -100,4 +100,19 @@ public class NavigationViewService : INavigationViewService
 
         return false;
     }
+
+    // Copilot suggested this method to sync the selected item in the NavigationView
+    public void SyncSelectedItem(Type? pageType)
+    {
+        if (pageType is null)
+        {
+            return;
+        }
+
+        var item = GetSelectedItem(pageType);
+        if (item is not null)
+        {
+            _navigationView?.SelectedItem = item;
+        }
+    }
 }

--- a/Center windows winui/ViewModels/ShellViewModel.cs
+++ b/Center windows winui/ViewModels/ShellViewModel.cs
@@ -91,16 +91,16 @@ public partial class ShellViewModel : ObservableRecipient
     {
         IsBackEnabled = NavigationService.CanGoBack;
 
-        if (e.SourcePageType == typeof(SettingsPage))
-        {
-            Selected = NavigationViewService.SettingsItem;
-            return;
-        }
-
         var selectedItem = NavigationViewService.GetSelectedItem(e.SourcePageType);
-        if (selectedItem != null)
+        if (selectedItem is not null)
         {
             Selected = selectedItem;
+        }
+
+        // Copilot suggested this line, but it seems redundant since SyncSelectedItem is called in the constructor.
+        if (NavigationService.Frame is not null)
+        {
+            NavigationViewService.SyncSelectedItem(NavigationService.Frame.CurrentSourcePageType);
         }
     }
 


### PR DESCRIPTION
Modify ``OnNavigated`` event handler to properly update the visuals of the current ``selectedItem``.