### PR TITLE
Refine minimize to tray

### DIFF
--- a/Center windows winui/App.xaml.cs
+++ b/Center windows winui/App.xaml.cs
@@ -171,7 +171,7 @@ public partial class App : Application
         if (settings.GetValues.LaunchAtStartup)
         {
             mainWindowService.Hide();
-            _trayIconService.Initialize();
+            _trayIconService.Initialize();  // This should be already initializated, but we ensure the tray icon is set up
             settings.GetValues.LaunchAtStartup = true; // Ensure the setting is true
         }
 

--- a/Center windows winui/Models/AppSettings.cs
+++ b/Center windows winui/Models/AppSettings.cs
@@ -99,6 +99,12 @@ public partial class AppSettings
     [JsonPropertyName("Launch app on startup")]
     public bool LaunchAtStartup { get; set; } = false;
 
+    /// <summary>
+    /// The application can only be minimized to the system tray if both <see cref="ShowTrayIcon"/> and <see cref="MinimizeToTray"/> are true.
+    /// </summary>
+    [JsonIgnore]
+    public bool CanMinimizeToTray => ShowTrayIcon && MinimizeToTray;
+
     [JsonIgnore]
     public string? AppPath { get; set; } = Path.GetDirectoryName(Environment.ProcessPath);
     [JsonIgnore]

--- a/Center windows winui/Services/MainWindowService.cs
+++ b/Center windows winui/Services/MainWindowService.cs
@@ -1,5 +1,7 @@
 ﻿using CenterWindow.Contracts.Services;
 using CenterWindow.Interop;
+using CenterWindow.Models;
+using CenterWindow.ViewModels;
 using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace CenterWindow.Services;
@@ -7,6 +9,7 @@ public partial class MainWindowService : ObservableObject, IMainWindowService, I
 {
     private readonly WindowEx _window;
     private readonly IntPtr _hWnd;
+    private readonly ILocalSettingsService<AppSettings> _settingsService;
 
     [ObservableProperty]
     public partial int WindowLeft { get; set; }
@@ -43,7 +46,11 @@ public partial class MainWindowService : ObservableObject, IMainWindowService, I
         // Subscribe to window position and size change events
         window.SizeChanged          += OnSizeChanged;
         window.PositionChanged      += OnPositionChanged;
-        window.WindowStateChanged   += OnWindowStateChanged; ;
+        window.WindowStateChanged   += OnWindowStateChanged;
+
+        // Get the settings service
+        _settingsService = App.GetService<ILocalSettingsService<AppSettings>>();
+        
     }
 
     public void Dispose()
@@ -69,9 +76,10 @@ public partial class MainWindowService : ObservableObject, IMainWindowService, I
     {
         if (e == WindowState.Minimized)
         {
-            Hide();
-            // Y dejamos que el servicio de bandeja muestre su icono
-            // (el propio MainWindow.xaml.cs ya habrá inicializado ITrayIconService)
+            if (_settingsService.GetValues.CanMinimizeToTray)
+            {
+                Hide();
+            }
         }
     }
 


### PR DESCRIPTION
Make sure the app hiding on minimization occurs only when the tray icon is already set up and the settings option to minimize to tray is true.
Make double check (and add comments) that the tray icon is set up in App OnLanched event handler.