### PR TITLE
Avoid static initialization issues in ResourceExtensions

### DIFF
--- a/Center windows winui/Helpers/ResourceExtensions.cs
+++ b/Center windows winui/Helpers/ResourceExtensions.cs
@@ -5,30 +5,28 @@ namespace CenterWindow.Helpers;
 
 public static class ResourceExtensions
 {
-    private static Lazy<ResourceLoader> _resourceLoader = new(() => new ResourceLoader());
-    private static Lazy<ILocalizationService> _localizationService = new(App.GetService<ILocalizationService>);
+    //private static Lazy<ResourceLoader> _resourceLoader = new(() => new ResourceLoader());
+    //private static Lazy<ILocalizationService> _localizationService = new(App.GetService<ILocalizationService>);
 
-    public static string GetLocalized(this string resourceKey, string? resourceMap = null)
+    public static string GetLocalized(this string resourceKey)
     {
-        string stringValue;
-        if (resourceMap is null)
-        {
-            stringValue = _resourceLoader.Value.GetString(resourceKey);
-        }
-        else
-        {
-            stringValue = _localizationService.Value.GetString(resourceKey, resourceMap);
-        }
-        return stringValue;
+        var resourceLoader = new ResourceLoader();
+        return resourceLoader.GetString(resourceKey);
     }
 
-    public static void Refresh()
+    public static string GetLocalized(this string resourceKey, string resourceMap)
     {
-        // Reset WinRT resource context
-        Windows.ApplicationModel.Resources.Core.ResourceContext.GetForCurrentView().Reset();
-
-        // Substituting the Lazy instances to force a new instance
-        _resourceLoader = new(() => new ResourceLoader());
-        _localizationService = new(App.GetService<ILocalizationService>);
+        var localizationService = App.GetService<ILocalizationService>();
+        return localizationService.GetString(resourceKey, resourceMap);
     }
+
+    //public static void Refresh()
+    //{
+    //    // Reset WinRT resource context
+    //    Windows.ApplicationModel.Resources.Core.ResourceContext.GetForCurrentView().Reset();
+
+    //    // Substituting the Lazy instances to force a new instance
+    //    _resourceLoader = new(() => new ResourceLoader());
+    //    _localizationService = new(App.GetService<ILocalizationService>);
+    //}
 }


### PR DESCRIPTION
Avoid static initialization issues in ResourceExtensions in order to prevent exceptions caused by accessing WinRT APIs or DI before the app is ready:

• Remove static fields that depend on WinRT or DI services (like ResourceLoader and _localizationService).

• Create instances or resolve services inside methods instead of at class load time.

This approach ensures the extension methods are safe to use at any point in the app lifecycle.